### PR TITLE
jobprocessor: Fix error being silently caught in fileParser

### DIFF
--- a/packages/jobprocessor/lib/fileParser.js
+++ b/packages/jobprocessor/lib/fileParser.js
@@ -226,9 +226,11 @@ function addJobsFromSortedFile(filepath, options, addJobCallback) {
                 .on('end', function () {
                     try {
                         addJob();
-                        resolve(Promise.all(jobPromises).then(function (titles) {
-                            return [].concat.apply([], titles).sort();
-                        }));
+                        Promise.all(jobPromises)
+                            .then(function (titles) {
+                                return [].concat.apply([], titles).sort();
+                            })
+                            .then(resolve);
                     } catch (err) {
                         reject(err);
                     }
@@ -283,7 +285,6 @@ function fileParser(filepath, options, addJobCallback) {
                 return tempFiles2.length > 0 ? sortFile(tempFiles2, cleanupList) : false;
             }).then(function (sortedFile) {
                 if (sortedFile) {
-                    cleanupList.push(sortedFile);
                     return addJobsFromSortedFile(sortedFile, options, addJobCallback);
                 } else {
                     return [];


### PR DESCRIPTION
This PR fixes an old issue with how Redis errors are handled. A promise was resolved before inner errors could be raised.